### PR TITLE
greater aperture -> smaller depth of field

### DIFF
--- a/R/render_scene.R
+++ b/R/render_scene.R
@@ -15,7 +15,7 @@
 #' @param lookat Default `c(0,0,0)`. Location where the camera is pointed.
 #' @param camera_up Default `c(0,1,0)`. Vector indicating the "up" position of the camera.
 #' @param aperture Default `0.1`. Aperture of the camera. Smaller numbers will increase depth of field, causing
-#' more blurring in areas not in focus.
+#' less blurring in areas not in focus.
 #' @param clamp_value Default `Inf`. If a bright light or a reflective material is in the scene, occasionally
 #' there will be bright spots that will not go away even with a large number of samples. These 
 #' can be removed (at the cost of slightly darkening the image) by setting this to a small number greater than 1. 
@@ -102,7 +102,7 @@
 #'              samples=500)
 #' }
 #'                  
-#'#Increase the aperture to give more depth of field.
+#'#Increase the aperture to blur objects that are further from the focal plane.
 #' \donttest{
 #' render_scene(scene,lookfrom = c(7,1.5,10),lookat = c(0,0.5,0),fov=15,
 #'              aperture = 0.5,parallel=TRUE,samples=500)


### PR DESCRIPTION
Sorry to keep hassling you on this issue as it's a rehash of #5.  I think the current docs still conflict with observed `rayrender` behavior, i.e. that *smaller* apertures lead to *larger* depths of field, meaning more things are in focus.  The following experiment appears to demonstrate this, with the very small aperture having everything in focus.  The behavior `rayrender` exhibits coincides with my understanding of aperture in photography.

Also, from [wikipedia we have](https://en.wikipedia.org/wiki/Depth_of_field):

> For many cameras, depth of field (DOF) is the distance between the nearest and the farthest objects that are in acceptably sharp focus in an image.

So larger depth of field should mean more things in focus.  Sorry to be a PITA.  Feel free to ignore all this if it's too much.

Finally, apologies for not basing this off of head but due to the ambient light issue #10 I couldn't get the examples below to work.

``` r
library(rayrender)
cylsl <- lapply(5:(-5), function(x) cylinder(length=3, x=-.5, z=x*2, y=1.5, material=diffuse('yellow'), radius=.1))
cylsr <- lapply(5:(-5), function(x) cylinder(length=3, x=.5, z=x*2, y=1.5, material=diffuse('yellow'), radius=.1))

scene = generate_ground(depth=-0.5, material = diffuse(color="white", checkercolor="darkgreen"))

# small aperture: sharp throughout, i.e. large depth of field

render_scene(
  dplyr::bind_rows(c(list(scene), cylsl, cylsr)),
  parallel=TRUE, samples=100, fov=45, aperture=0.00000001
)
```

![](https://i.imgur.com/YwLLjsy.png)

``` r
# large aperture: blurry except at focal plane, i.e. shallow depth of field

render_scene(
  dplyr::bind_rows(c(list(scene), cylsl, cylsr)),
  parallel=TRUE, samples=100, fov=45, aperture=1
)
```

![](https://i.imgur.com/Wj3ZXf7.png)

<sup>Created on 2019-11-11 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>