### PR TITLE
Extruded Polygon Side Face Normals and Other Issues

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: rayrender
 Type: Package
 Title: Build and Raytrace 3D Scenes
-Version: 0.10.0
+Version: 0.10.0.9000
 Authors@R: c(person("Tyler", "Morgan-Wall", email = "tylermw@gmail.com",
     role = c("aut", "cph", "cre"), comment = c(ORCID = "0000-0002-3131-3814")),
     person("Syoyo", "Fujita", role=c("ctb", "cph")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: rayrender
 Type: Package
 Title: Build and Raytrace 3D Scenes
-Version: 0.10.0.9000
+Version: 0.10.0
 Authors@R: c(person("Tyler", "Morgan-Wall", email = "tylermw@gmail.com",
     role = c("aut", "cph", "cre"), comment = c(ORCID = "0000-0002-3131-3814")),
     person("Syoyo", "Fujita", role=c("ctb", "cph")),

--- a/R/objects.R
+++ b/R/objects.R
@@ -1253,7 +1253,7 @@ extruded_polygon = function(polygon = NULL, x = 0, y = 0, z = 0, plane = "xz",
           stop("holes cannot begin before vertex 4. Hole index here starts at: ", hole_start)
         }
         holes = rep(TRUE, nrow(poly_list[[poly]]))
-        holes[1:hole_start] = FALSE
+        holes[1:(hole_start-1)] = FALSE
       }
     } else {
       holes = poly_list[[poly]][,3] == 1

--- a/R/objects.R
+++ b/R/objects.R
@@ -1188,8 +1188,8 @@ extruded_polygon = function(polygon = NULL, x = 0, y = 0, z = 0, plane = "xz",
           0
         } else {
           which(
-            c(FALSE, diff(x[,4]) > 0) &             # start id of each "part"
-            seq_len(nrow(x)) >= which(x[,3] > 0)[1] # for holes
+            c(TRUE, diff(x[,4]) > 0) &     # start position of each "part"
+            x[,3] > 0                      # that correspond to holes
           )
     } } )
   } else {

--- a/R/objects.R
+++ b/R/objects.R
@@ -1309,8 +1309,8 @@ extruded_polygon = function(polygon = NULL, x = 0, y = 0, z = 0, plane = "xz",
         # assumes non-intersecting polygon (side is a closed polygon).  CW
         # outer polygon need to flip sides, as do CCW holes
 
-        i <- polyv[seq_len(length(polyv) - 2L)]
-        ii <- polyv[seq_len(length(polyv) - 2L) + 1L]   # i + 1
+        i <- polyv[seq_len(length(polyv) - 1L)]
+        ii <- polyv[seq_len(length(polyv) - 1L) + 1L]   # i + 1
         area_s <- sum(x[i] * y[ii] - x[ii] * y[i]) / 2
 
         ccw <- area_s >= 0  # treat degenerates as counter-clockwise

--- a/R/objects.R
+++ b/R/objects.R
@@ -880,9 +880,8 @@ ellipsoid = function(x = 0, y = 0, z = 0, a = 1, b = 1, c = 1,
 #'
 #' @param polygon `sf` object, "SpatialPolygon" `sp` object,  or xy coordinates
 #'   of polygon represented in a way that can be processed by `xy.coords()`.  If
-#'   an `sf` object contains non-polygon geometries, those will be dropped.  If
-#'   the latter type of polygon is open, it will be closed by adding an edge from
-#'   the last point to the first.
+#'   xy-coordinate based polygons are open, they will be closed by adding an
+#'   edge from the last point to the first.
 #' @param x Default `0`. x-coordinate to offset the extruded model.
 #' @param y Default `0`. y-coordinate to offset the extruded model.
 #' @param z Default `0`. z-coordinate to offset the extruded model.
@@ -1112,7 +1111,6 @@ extruded_polygon = function(polygon = NULL, x = 0, y = 0, z = 0, plane = "xz",
     if(!"sf" %in% rownames(utils::installed.packages())) {
       stop("sf package required when handling sf objects")
     }
-    polygon = sf::st_collection_extract(polygon, "POLYGON")
     poly_info = sf::st_drop_geometry(polygon)
     polygon = sf::as_Spatial(polygon)
     if(!is.null(data_column_top)) {

--- a/R/objects.R
+++ b/R/objects.R
@@ -1332,7 +1332,7 @@ extruded_polygon = function(polygon = NULL, x = 0, y = 0, z = 0, plane = "xz",
         R <- matrix(c(cos(e1e2), sin(e1e2), -sin(e1e2), cos(e1e2)), 2)
         right <- (R %*% e2)[1] >= 0 # if positive x offset, triangle on right
 
-        for(i in seq_len(length(side - 1))) {
+        for(i in seq_len(length(side) - 1L)) {
           xi <- x[side[i]]        # vertex i
           yi <- y[side[i]]
           xii <- x[side[i + 1L]]  # vertex i + 1

--- a/R/objects.R
+++ b/R/objects.R
@@ -1251,7 +1251,10 @@ extruded_polygon = function(polygon = NULL, x = 0, y = 0, z = 0, plane = "xz",
   }
   scenelist= list()
   counter = 1
-  
+
+  if(!(flip_horizontal && flip_vertical) && ((flip_horizontal || flip_vertical))) {
+    reversed = !reversed
+  }
   for(poly in 1:length(poly_list)) {
     x=poly_list[[poly]][,1]
     y=poly_list[[poly]][,2]
@@ -1302,9 +1305,6 @@ extruded_polygon = function(polygon = NULL, x = 0, y = 0, z = 0, plane = "xz",
     #   for(1:length(polylist)) loop?  Otherwise are we not going to be
     #   alternating value each loop?  Doesn't affect base polygons, so maybe
     #   that's okay give input format from other poly sources?
-    if(!(flip_horizontal && flip_vertical) && ((flip_horizontal || flip_vertical))) {
-      reversed = !reversed
-    }
     if(extruded) {
       for(side in split(seq_along(x), holes)) {
         # Find first edge in earcut list, and check whether the corresponding

--- a/R/objects.R
+++ b/R/objects.R
@@ -1153,8 +1153,8 @@ extruded_polygon = function(polygon = NULL, x = 0, y = 0, z = 0, plane = "xz",
     # Holes are only holes if every hole value of `part` column (col 2) is a
     # hole to match original code (seems like it should always be true?).
 
-    opart <- interaction(coord_data[, 1], coord_data[, 2], drop=TRUE)
-    coord_data[, 4] <- ave(coord_data[, 4], opart, FUN=min)
+    opart = interaction(coord_data[, 1], coord_data[, 2], drop=TRUE)
+    coord_data[, 4] = ave(coord_data[, 4], opart, FUN=min)
 
     # Every `part` is considered a polygon, unless it is a hole, in which case
     # it is assumed to be a hole in the nearest preceding non-hole polygon.
@@ -1170,7 +1170,7 @@ extruded_polygon = function(polygon = NULL, x = 0, y = 0, z = 0, plane = "xz",
 
     coord_data[, 4] = coord_data[, 4] * coord_data[, 3]
 
-    # remap the new object id to old
+    # remap the new object id to old to get height data
 
     obj_new_len = rle(object_new)[['lengths']]
     obj_map_id = object[c(1L, cumsum(obj_new_len)[-length(obj_new_len)] + 1L)]
@@ -1216,28 +1216,28 @@ extruded_polygon = function(polygon = NULL, x = 0, y = 0, z = 0, plane = "xz",
     # label each vertex with a hole id
 
     if(isTRUE(holes == 0)) {
-      xy_dat <- data.frame(x, y, holes=0L)
+      xy_dat = data.frame(x, y, holes=0L)
     } else {
-      xy_dat <- data.frame(x, y, holes=cumsum(seq_along(x) %in% holes))
+      xy_dat = data.frame(x, y, holes=cumsum(seq_along(x) %in% holes))
     }
     # close polygons if not closed, must do so for outer and each hole;
     # sf and Spatial polygons should be closed
 
-    xy_dat_split <- split(xy_dat, xy_dat[['holes']])
-    close_poly <- function(dat) {
+    xy_dat_split = split(xy_dat, xy_dat[['holes']])
+    close_poly = function(dat) {
       if(!all(dat[1L,] == dat[nrow(dat),])) {
         dat[c(seq_len(nrow(dat)), 1L),]
       } else dat
     }
-    xy_dat_closed <- lapply(xy_dat_split, close_poly)
-    xy_dat_len <- vapply(xy_dat_closed, nrow, 0)
-    holes <- if(length(xy_dat_closed) > 1) {
+    xy_dat_closed = lapply(xy_dat_split, close_poly)
+    xy_dat_len = vapply(xy_dat_closed, nrow, 0)
+    holes = if(length(xy_dat_closed) > 1) {
       cumsum(xy_dat_len[-length(xy_dat_closed)]) + 1L
     } else 0L
-    xy_dat_fin <- do.call(rbind, xy_dat_closed)
-    rownames(xy_dat_fin) <- NULL
+    xy_dat_fin = do.call(rbind, xy_dat_closed)
+    rownames(xy_dat_fin) = NULL
 
-    holes_start_i_list[[1]] <- holes  # hole indices for decido::earcut
+    holes_start_i_list[[1]] = holes  # hole indices for decido::earcut
     poly_list[[1]] = as.matrix(xy_dat_fin)
     height_list[[1]] = data_vals_top
     bottom_list[[1]] = data_vals_bottom
@@ -1311,20 +1311,20 @@ extruded_polygon = function(polygon = NULL, x = 0, y = 0, z = 0, plane = "xz",
         # assumes non-intersecting polygon (side is a closed polygon).  CW
         # outer polygon need to flip sides, as do CCW holes
 
-        i <- polyv[seq_len(length(polyv) - 1L)]
-        ii <- polyv[seq_len(length(polyv) - 1L) + 1L]   # i + 1
-        area_s <- sum(x[i] * y[ii] - x[ii] * y[i]) / 2
+        i = polyv[seq_len(length(polyv) - 1L)]
+        ii = polyv[seq_len(length(polyv) - 1L) + 1L]   # i + 1
+        area_s = sum(x[i] * y[ii] - x[ii] * y[i]) / 2
 
-        ccw <- area_s >= 0  # treat degenerates as counter-clockwise
-        side_rev <- (
+        ccw = area_s >= 0  # treat degenerates as counter-clockwise
+        side_rev = (
           (holes[polyv[1L]] == 0L && !ccw) ||
           (holes[polyv[1L]] != 0L && ccw)
         )
         for(i in seq_len(length(polyv) - 1L)) {  # polygons are closed
-          xi <- x[polyv[i]]        # vertex i
-          yi <- y[polyv[i]]
-          xii <- x[polyv[i + 1L]]  # vertex i + 1
-          yii <- y[polyv[i + 1L]]
+          xi = x[polyv[i]]        # vertex i
+          yi = y[polyv[i]]
+          xii = x[polyv[i + 1L]]  # vertex i + 1
+          yii = y[polyv[i + 1L]]
 
           scenelist[[counter]] = triangle(v1=scale*permute_axes(c(xi,height_poly,yi),planeval),
                                           v2=scale*permute_axes(c(xi,bottom_poly,yi),planeval),

--- a/R/objects.R
+++ b/R/objects.R
@@ -1322,7 +1322,7 @@ extruded_polygon = function(polygon = NULL, x = 0, y = 0, z = 0, plane = "xz",
         # and apply rotation to e2 to see which "side" e2 is pointing
         # by looking at resulting x value (not super efficient...).
 
-        e1e2 <- acos(sum(e1  * c(0, 1)) / (sqrt(sum(e1^2)))) * sign(e1[['x']])
+        e1e2 <- acos(sum(e1  * c(0, 1)) / (sqrt(sum(e1^2)))) * if(e1[['x']] < 0)  -1 else 1
         R <- matrix(c(cos(e1e2), sin(e1e2), -sin(e1e2), cos(e1e2)), 2)
         right <- (R %*% e2)[1] >= 0 # if positive x offset, triangle on right
 

--- a/R/objects.R
+++ b/R/objects.R
@@ -933,7 +933,7 @@ ellipsoid = function(x = 0, y = 0, z = 0, a = 1, b = 1, c = 1,
 #' 
 #' #Now, let's add a hole to the center of the polygon. We'll make the polygon
 #' #hollow by shrinking it, combining it with the normal size polygon,
-#' #and specify with the `hole` argument that everything after `nrow(star_polygon)`
+#' #and specify with the `holes` argument that everything after `nrow(star_polygon)`
 #' #in the following should be used to draw a hole:
 #' 
 #' hollow_star = rbind(star_polygon,0.8*star_polygon)
@@ -941,7 +941,7 @@ ellipsoid = function(x = 0, y = 0, z = 0, a = 1, b = 1, c = 1,
 #' \donttest{
 #' generate_ground(depth=-0.01,
 #'                 material = diffuse(color="grey50",checkercolor="grey20")) %>%
-#'   add_object(extruded_polygon(hollow_star,top=0.25,bottom=0, hole = nrow(star_polygon),
+#'   add_object(extruded_polygon(hollow_star,top=0.25,bottom=0, holes = nrow(star_polygon) + 1,
 #'                               material=diffuse(color="red",sigma=90))) %>%
 #'   add_object(sphere(y=4,x=-3,z=-3,material=light(intensity=30))) %>%
 #'   render_scene(parallel=TRUE,lookfrom = c(0,2,4),samples=400,lookat=c(0,0,0),fov=30)
@@ -952,10 +952,10 @@ ellipsoid = function(x = 0, y = 0, z = 0, a = 1, b = 1, c = 1,
 #' \donttest{
 #' generate_ground(depth=-0.01,
 #'                 material = diffuse(color="grey50",checkercolor="grey20")) %>%
-#'   add_object(extruded_polygon(hollow_star,top=0.25,bottom=0, hole = nrow(star_polygon),
+#'   add_object(extruded_polygon(hollow_star,top=0.25,bottom=0, holes = nrow(star_polygon),
 #'                               material=diffuse(color="red",sigma=90))) %>%
 #'   add_object(extruded_polygon(hollow_star,top=0.25,bottom=0, y=1.2, z=-1.2, 
-#'                               hole = nrow(star_polygon), plane = "yx", 
+#'                               holes = nrow(star_polygon) + 1, plane = "yx", 
 #'                               material=diffuse(color="green",sigma=90))) %>%
 #'   add_object(sphere(y=4,x=-3,material=light(intensity=30))) %>%
 #'   render_scene(parallel=TRUE,lookfrom = c(0,2,4),samples=400,lookat=c(0,0.9,0),fov=40)
@@ -965,13 +965,13 @@ ellipsoid = function(x = 0, y = 0, z = 0, a = 1, b = 1, c = 1,
 #' \donttest{
 #' generate_ground(depth=-0.01,
 #'                 material = diffuse(color="grey50",checkercolor="grey20")) %>%
-#'   add_object(extruded_polygon(hollow_star,top=0.25,bottom=0, hole = nrow(star_polygon),
+#'   add_object(extruded_polygon(hollow_star,top=0.25,bottom=0, holes = nrow(star_polygon) + 1,
 #'                               material=diffuse(color="red",sigma=90))) %>%
 #'   add_object(extruded_polygon(hollow_star,top=0.25,bottom=0, y=1.2, z=-1.2, 
-#'                               hole = nrow(star_polygon), plane = "yx", 
+#'                               holes = nrow(star_polygon) + 1, plane = "yx", 
 #'                               material=diffuse(color="green",sigma=90))) %>%
 #'   add_object(extruded_polygon(hollow_star,top=0.25,bottom=0, y=1.2, x=1.2, 
-#'                               hole = nrow(star_polygon), plane = "zy", 
+#'                               holes = nrow(star_polygon) + 1, plane = "zy", 
 #'                               material=diffuse(color="blue",sigma=90))) %>%
 #'   add_object(sphere(y=4,x=-3,material=light(intensity=30))) %>%
 #'   render_scene(parallel=TRUE,lookfrom = c(-4,2,4),samples=400,lookat=c(0,0.9,0),fov=40)

--- a/R/objects.R
+++ b/R/objects.R
@@ -879,7 +879,8 @@ ellipsoid = function(x = 0, y = 0, z = 0, a = 1, b = 1, c = 1,
 #' Extruded Polygon Object
 #'
 #' @param polygon `sf` object or xy coordinates of polygon represented in a way that can be processed 
-#' by `xy.coords()`.
+#'   by `xy.coords()`.  If the latter type of polygon is open, it will be closed by adding an edge from the last
+#'   point to the first.
 #' @param x Default `0`. x-coordinate to offset the extruded model.
 #' @param y Default `0`. y-coordinate to offset the extruded model.
 #' @param z Default `0`. z-coordinate to offset the extruded model.
@@ -1137,6 +1138,9 @@ extruded_polygon = function(polygon = NULL, x = 0, y = 0, z = 0, plane = "xz",
     data_vals_bottom = bottom[1]
   }
   if(inherits(polygon,"SpatialPolygonsDataFrame") || inherits(polygon,"SpatialPolygons")) {
+    if(!is.null(holes)) {
+      warning("holes is not NULL, but is unused when input is sf or Spatial")
+    }
     coord_data = raster::geom(polygon)
     unique_objects = unique(coord_data[,1])
     counter_obj = 1

--- a/R/objects.R
+++ b/R/objects.R
@@ -878,9 +878,11 @@ ellipsoid = function(x = 0, y = 0, z = 0, a = 1, b = 1, c = 1,
 
 #' Extruded Polygon Object
 #'
-#' @param polygon `sf` object or xy coordinates of polygon represented in a way that can be processed 
-#'   by `xy.coords()`.  If the latter type of polygon is open, it will be closed by adding an edge from the last
-#'   point to the first.
+#' @param polygon `sf` object, "SpatialPolygon" `sp` object,  or xy coordinates
+#'   of polygon represented in a way that can be processed by `xy.coords()`.  If
+#'   an `sf` object contains non-polygon geometries, those will be dropped.  If
+#'   the latter type of polygon is open, it will be closed by adding an edge from
+#'   the last point to the first.
 #' @param x Default `0`. x-coordinate to offset the extruded model.
 #' @param y Default `0`. y-coordinate to offset the extruded model.
 #' @param z Default `0`. z-coordinate to offset the extruded model.
@@ -1110,6 +1112,7 @@ extruded_polygon = function(polygon = NULL, x = 0, y = 0, z = 0, plane = "xz",
     if(!"sf" %in% rownames(utils::installed.packages())) {
       stop("sf package required when handling sf objects")
     }
+    polygon = sf::st_collection_extract(polygon, "POLYGON")
     poly_info = sf::st_drop_geometry(polygon)
     polygon = sf::as_Spatial(polygon)
     if(!is.null(data_column_top)) {

--- a/R/objects.R
+++ b/R/objects.R
@@ -1262,7 +1262,13 @@ extruded_polygon = function(polygon = NULL, x = 0, y = 0, z = 0, plane = "xz",
     y_h = y[holes]
     x = x[!holes]
     y = y[!holes]
-    flipped = FALSE
+
+    # Two questions
+    # * should this also affect the for(1:nrow(vertices)) loop?
+    # * do we need a different var name, or do this outside of the
+    #   for(1:length(polylist)) loop?  Otherwise are we not going to be
+    #   alternating value each loop?  Doesn't affect base polygons, so maybe
+    #   that's okay give input format from other poly sources?
     if(!(flip_horizontal && flip_vertical) && ((flip_horizontal || flip_vertical))) {
       reversed = !reversed
     }

--- a/R/render_scene.R
+++ b/R/render_scene.R
@@ -431,9 +431,11 @@ render_scene = function(scene, width = 400, height = 400, fov = 20,
   assertthat::assert_that(roulette_active_depth > 0)
   
   
-  #Material ID handler
+  #Material ID handler; these must show up in increasing order.  Note, this will
+  #cause problems if `match` is every changed to return doubles when matching in
+  #long vectors as has happened with `which` recently.
   material_id = scene$material_id
-  material_id = as.integer(as.factor(material_id))-1
+  material_id = as.integer(match(material_id, unique(material_id)) - 1L)
   material_id_bool = !is.na(scene$material_id)
   
   if(min_adaptive_size < 1) {


### PR DESCRIPTION
## Thanks!

First, thanks a bunch for implementing this feature.  It really adds a new
dimension (!) to rayrender.  It came in quite handy as I had it on my backburner
to implement something similar manually.

More generally, thanks for getting path tracing into R.  I might never have 
played this closely with it otherwise, and it's been a great value-add to my life.

Now, in using it I discovered a few possible issues.  All these issues
ended up being closely related and as I tried understanding what was going on I
fixed them and they all kind of rely on each other so it is more work than I
think it's worth to split them up into separate issues (though some could be).

Also, I realize that it's bad form of me to submit a patch without first
submitting the bug report, particularly one as extensive as this one.  I'm
loathe to submit bug reports without at least doing some work to figure what's
going on and one thing led to another and here we are.  I realize that there is
a good chance you're already fixed much of this in your internal versions, and
that you might balk at the magnitude of this patch, but I guess that's the risk
I took by getting hooked on wanting to fix this.

I've tried to be reasonably careful about what I'm doing, and tried to test as
much as possible, but I'll admit finding flipped face normals is tricky, and
this is not my domain of expertise.

All the code I used to generate the below is in [this gist][4].

## Base Polygons are Assumed to be Closed

AFAICT this is what SF does, but many polygon applications in R will self close
polygons, including `decido`, `graphics::polygon`, and others.  It might be
worth either documenting and checking that inputs comply, or alternatively as in
this patch auto-close any open polygons.

Here we compare an extruded cube (left) with a `cube` (right).  Notice how the
back is open:

![01_cube-open-cw](https://user-images.githubusercontent.com/6105908/80893100-57433d80-8c9d-11ea-8032-c1d2491afe6d.png)

Auto-closing polygons as in the patch resolves this:

![01_cube-open-cw](https://user-images.githubusercontent.com/6105908/80892657-cb7be200-8c99-11ea-8ec2-229eca165259.png)

Another option is to document that polygons are required to be closed, but it's
easy enough to do this automatically.

## Polygon Path Direction Affect Side Triangle Normals

With the current logic depending on which direction the polygon input in the
side polygons will end up with flipped normals.   The colors indicate that the side
face normals are flipped.

Note we are now viewing the scene from the opposite direction as the previous one,
so this time the `cube` cube is on the left, and the extruded one on the right. 

![02_cube-cw](https://user-images.githubusercontent.com/6105908/80893106-5f9b7880-8c9d-11ea-92bf-a6dfb0743ef8.png)

This may only be an issue with manually specified polygons, but it's easy and
cheap to check the winding with a signed area calculation so we can specify the
correct side as this patch does:

![02_cube-cw](https://user-images.githubusercontent.com/6105908/80892667-db93c180-8c99-11ea-90b5-0499abd27225.png)

The effect is particularly noticeable in holes, showing on the left a version
hacked together with `cube`s, and on the right an extrusion with a hole:

![03_cube-hole](https://user-images.githubusercontent.com/6105908/80893129-83f75500-8c9d-11ea-9dc7-b6f65c1388b5.png)

After patch:

![03_cube-hole](https://user-images.githubusercontent.com/6105908/80892691-21508a00-8c9a-11ea-8933-95147001f93f.png)

And the same thing now only extruded versions rotated so we can better see them:

![04_cube-hole-angles](https://user-images.githubusercontent.com/6105908/80893132-8d80bd00-8c9d-11ea-911e-09be04709bf1.png)

After patch:

![04_cube-hole-angles](https://user-images.githubusercontent.com/6105908/80892695-2ca3b580-8c9a-11ea-906f-29082c92704c.png)

## Decido Earcut Hole Index Is First Vertex of Hole

Currently, examples use the last index of the outside polygon as the starting
vertex for the holes.  This happens to work when polygons are explicitly closed,
but I believe it adds an extra vertex to the hole, you end up with:

```
intended?        actual?
+-----+          +-----+
|     |          |\    |   <<- diagonal face is part of the hole
| +-+ |          | +-+ |
| | | |          | | | |
| +-+ |          | +-+ |
|     |          |     |
+-----+          +-----+
```

With closed polygons you can't see this, but if that edge ends up
crossing another hole or a convexity in the outer polygon it will become
visible.  Additionally, it seems worth changing if only to match what `decido`
does.

I'm going off the [`decido` vignette][2] which I read to indicate we want the
first index in the hole polygon..

## Only one Hole is Supported

Logic assumes that only one hole is present, but `decido` documents (and
supports) multiple holes, as does SF.  The patch adds support for multiple
holes.  Attempting two holes with manually specified polygons fails:

```
Error in data.frame(x = x, y = y, hole = holes) : 
  arguments imply differing number of rows: 15, 2
```

With the patch applied it works:

![04_cube-holes-two](https://user-images.githubusercontent.com/6105908/80892706-388f7780-8c9a-11ea-8406-279852e86002.png)

This will appear to work with `sf` polygons with holes in some cases, but it is
because the hole is rendered like so:

```
+----------+
|          |
| +-+--+-+ |  <<- One hole masquerading as two
| | |  | | |
| +-+  +-+ |
|          |
+----------+
```

Here is an image comparing after the patch (left) and before the patch (right) with 
the code modified to omit the top/bottom faces so you can see inside.  Notice
how the pre-patch (right) has a face connecting the two holes.  This is the
same polygons used for the `sf` tests near the end of this PR.  

<img width="547" alt="inside-connection" src="https://user-images.githubusercontent.com/6105908/80892731-5e1c8100-8c9a-11ea-864a-dc6df16d9b81.png">

This is probably fine in many cases, but could cause problems with non-convex
polygons or joining edges that show up inside holes.

## Material Ids Were Implicitly Required to Be Ordered

The C++ logic assumes that material ids will show up in incrementing order.  If
this is not the case as happens if material ids are passed to `render_scene` in
non-increasing order, materials are incorrectly re-used.  Here you can see the
same color re-used:

![02_material-id](https://user-images.githubusercontent.com/6105908/80895198-40f2ad00-8cb0-11ea-911c-9c8e8c32f983.png)

The patch changes the logic for generating material ids to ensure they are
always ordered:

![02_material-id](https://user-images.githubusercontent.com/6105908/80892743-86a47b00-8c9a-11ea-97a9-1bc40568b2ff.png)

## Harmonizing SF and Base Logic

The logic for flipping vertical/horizontal, earcutting, and centering is
essentially the same for either SF or base polygons.  I normally wouldn't have
bothered harmonizing them because it works fine, but in this case the flipping
part was only applied to the SF derived polygons.  You can see that as we
attempt to render one polygon with all the flip permutations, and all
four polygons are rendered right on top of each other:

![06_arrows-flip](https://user-images.githubusercontent.com/6105908/80895202-4ea83280-8cb0-11ea-8ef2-0872fc760c65.png)

Post-patch you see all four correctly flipped horizontally/vertically:

![06_arrows-flip](https://user-images.githubusercontent.com/6105908/80892764-a340b300-8c9a-11ea-86b5-3eab0847ea9e.png)

Related, the following was inside the poly loop when generating the faces.
Since `decido` [always returns CCW faces][1] this should only be needed for the
side polygons, but because this was [inside the loop][3] it will affect the face
polygons after the first loop iteration.

```
if(!(flip_horizontal && flip_vertical) && ((flip_horizontal || flip_vertical))) {
  reversed = !reversed
}
```

Because the patch adds logic to auto-detect the desired winding for the side
polygons this reversing is no longer needed so I removed it.

## Multi-polygons in SF

`sf` objects may contain multi-polygons, where a single feature defines many
polygons.  The internal logic did not seem to explicitly handle this.  I didn't
dig too much into as I had to change so much to handle this as well as handle
multiple holes that it was easier to re-write.  With the multi-polygon polygons
in North Carolina this is what it looks like:

![ex-nc-multi](https://user-images.githubusercontent.com/6105908/80895207-61226c00-8cb0-11ea-9b16-00dd197a97d4.png)

With patch applied.

![ex-nc-multi](https://user-images.githubusercontent.com/6105908/80892827-177b5680-8c9b-11ea-94a7-8987023cb4bb.png)

All of NC:

![ex-nc-a](https://user-images.githubusercontent.com/6105908/80895215-739ca580-8cb0-11ea-92b7-50255e756ae4.png)

With patch:

![ex-nc-a](https://user-images.githubusercontent.com/6105908/80892836-2235eb80-8c9b-11ea-85c2-4868af55c7ce.png)

I also built a bunch of variations of multipolygon/polygon/base to compare them.
With these the main issues seemed to be alignment (in addition to side face normals).

Various examples follow.  Two simple polygons viewed from two angles, original:

![09a_sf-multi-holes-angle-1](https://user-images.githubusercontent.com/6105908/80895229-87480c00-8cb0-11ea-8366-297dd24f8fa9.png)

![09a_sf-multi-holes-angle-2](https://user-images.githubusercontent.com/6105908/80895237-8c0cc000-8cb0-11ea-8b5e-d182d2777f91.png)

With patch:

![09a_sf-multi-holes-angle-2](https://user-images.githubusercontent.com/6105908/80892620-717b1c80-8c99-11ea-8eae-069ff2c5033b.png)

![09a_sf-multi-holes-angle-1](https://user-images.githubusercontent.com/6105908/80892602-4c86a980-8c99-11ea-8a0e-080526a6dc29.png)

Same polygons, but this time as a single MULTIPOLYGON with two polygons:

![09a_sf-multi-holes-mp](https://user-images.githubusercontent.com/6105908/80895242-94fd9180-8cb0-11ea-8350-646baadd0818.png)

With patch (look at the shadows in the holes):

![09a_sf-multi-holes-mp](https://user-images.githubusercontent.com/6105908/80892631-8f488180-8c99-11ea-998a-02d6b8d21a7e.png)

The two POLYGONS, as well as the MULTIPOLYGON together all in one `sf` object:

![09a_sf-multi-holes-p-and-mp](https://user-images.githubusercontent.com/6105908/80895249-9dee6300-8cb0-11ea-8385-bccd9bf344fa.png)

With patch:

![09a_sf-multi-holes-p-and-mp](https://user-images.githubusercontent.com/6105908/80892639-b0a96d80-8c99-11ea-88db-454c673c67b0.png)

Other than the alignment, you can see how the face normals of the hole insides is wrong prior to patch.

## Examples

I ran some of the examples to make sure those still look good with the patch
applied:

![ex-hollow-star](https://user-images.githubusercontent.com/6105908/80892573-30830800-8c99-11ea-9e3d-83da9c1a8646.png)

![ex-texas](https://user-images.githubusercontent.com/6105908/80892579-37117f80-8c99-11ea-9adf-58cda783e12b.png)

I could not run all the states together as I got a C stack error (will report
separately).

[1]: https://github.com/hypertidy/decido/issues/17
[2]: https://hypertidy.github.io/decido/articles/decido.html#example
[3]: https://github.com/tylermorganwall/rayrender/blob/12857201f6ed94e7817e57c4fff296b35ff0c5b6/R/objects.R#L1266
[4]: https://gist.github.com/brodieG/fc99b0cee48f3c3a1433229fd33413ce
