### PR TITLE
added <limits> include to mathinline.h

### DIFF
--- a/src/mathinline.h
+++ b/src/mathinline.h
@@ -11,6 +11,7 @@
 
 #include "normal.h"
 #include <array>
+#include <limits>
 
 static const Float mpi_over_180 = M_PI/180;
 static const Float SqrtPiOver8 = 0.626657069f;


### PR DESCRIPTION
I ran into a problem compiling... not sure if it's my C++ version or something else. The fix was simple, found by googling the error finding [this](https://stackoverflow.com/questions/4798936/numeric-limits-was-not-declared-in-this-scope-no-matching-function-for-call-t).

As is, I get this error:
```
> library(devtools)
Loading required package: usethis
> devtools::install_github("tylermorganwall/rayrender")
Downloading GitHub repo tylermorganwall/rayrender@HEAD
SSL_INIT
SSL_INIT
SSL_INIT
Skipping 1 packages ahead of CRAN: spacefillr
   checking for file ‘/tmp/Rtmp0omYxD/remotes1598d525a9c3f0/tylermorganwall-rayrender-c27✔  checking for file ‘/tmp/Rtmp0omYxD/remotes1598d525a9c3f0/tylermorganwall-rayrender-c27e72f/DESCRIPTION’
─  preparing ‘rayrender’:
✔  checking DESCRIPTION meta-information ...
─  cleaning src
─  checking for LF line-endings in source and make files and shell scripts
─  checking for empty or unneeded directories
─  building ‘rayrender_0.23.4.tar.gz’
   
Installing package into ‘/home/jwhendy/.R’
(as ‘lib’ is unspecified)
* installing *source* package ‘rayrender’ ...
** using staged installation
** libs
g++ -std=gnu++11 -I"/usr/include/R/" -DNDEBUG  -I'/home/jwhendy/.R/Rcpp/include' -I'/home/jwhendy/.R/RcppThread/include' -I'/home/jwhendy/.R/progress/include' -I'/home/jwhendy/.R/spacefillr/include' -D_FORTIFY_SOURCE=2  -D RAY_REPRODUCE_PERLIN -DSTRICT_R_HEADERS -fpic  -march=x86-64 -mtune=generic -O2 -pipe -fno-plt  -c RcppExports.cpp -o RcppExports.o
g++ -std=gnu++11 -I"/usr/include/R/" -DNDEBUG  -I'/home/jwhendy/.R/Rcpp/include' -I'/home/jwhendy/.R/RcppThread/include' -I'/home/jwhendy/.R/progress/include' -I'/home/jwhendy/.R/spacefillr/include' -D_FORTIFY_SOURCE=2  -D RAY_REPRODUCE_PERLIN -DSTRICT_R_HEADERS -fpic  -march=x86-64 -mtune=generic -O2 -pipe -fno-plt  -c aabb.cpp -o aabb.o
In file included from ray.h:7,
                 from aabb.h:4,
                 from aabb.cpp:1:
mathinline.h:29:46: error: ‘numeric_limits’ is not a member of ‘std’
   29 | static constexpr Float MachineEpsilon = std::numeric_limits<Float>::epsilon() * 0.5;
      |                                              ^~~~~~~~~~~~~~
mathinline.h:29:66: error: expected primary-expression before ‘>’ token
   29 | static constexpr Float MachineEpsilon = std::numeric_limits<Float>::epsilon() * 0.5;
      |                                                                  ^
mathinline.h:29:69: error: ‘::epsilon’ has not been declared
   29 | static constexpr Float MachineEpsilon = std::numeric_limits<Float>::epsilon() * 0.5;
      |                                                                     ^~~~~~~
make: *** [/usr/lib64/R/etc/Makeconf:177: aabb.o] Error 1
ERROR: compilation failed for package ‘rayrender’
```

With the fix here, it built successfully.

*Note:* I don't know where you'd want that include line. I just added it wherever. Please fix if those are grouped or ordered in a meaningful way you'd like to maintain.