### PR TITLE
fix debug channel use for render_preview

### DIFF
--- a/R/prepare_scene_list.R
+++ b/R/prepare_scene_list.R
@@ -23,10 +23,25 @@ prepare_scene_list = function(scene, width = 400, height = 400, fov = 20,
     currenttime = proc.time()
     cat("Building Scene: ")
   }
-  if(debug_channel == "none" && is.na(max_depth)) {
+  if(!is.numeric(debug_channel)) {
+    debug_channel = unlist(lapply(tolower(debug_channel),switch,
+                                  "none" = 0,"depth" = 1,"normals" = 2, "uv" = 3, "bvh" = 4,
+                                  "variance" = 5, "normal" = 2, "dpdu" = 6, "dpdv" = 7, "color" = 8, 
+                                  "position" = 10, "direction" = 11, "time" = 12, "shape" = 13,
+                                  "pdf" = 14, "error" = 15, "bounces" = 16, "camera" = 17,
+                                  "ao" = 18, 0))
+    light_direction = c(0,1,0)
+  } else {
+    light_direction = debug_channel
+    debug_channel = 9
+  }
+  if(debug_channel == 4) {
+    message("rayrender must be compiled with option DEBUGBVH for this debug option to work")
+  }
+  if(debug_channel == 0 && is.na(max_depth)) {
     max_depth = 50
   }
-  if(debug_channel != "none" && is.na(max_depth)) {
+  if(debug_channel != 0 && is.na(max_depth)) {
     max_depth = 1
   }
   iso = iso/100
@@ -321,21 +336,6 @@ prepare_scene_list = function(scene, width = 400, height = 400, fov = 20,
   }
   if(!parallel) {
     numbercores = 1
-  }
-  if(!is.numeric(debug_channel)) {
-    debug_channel = unlist(lapply(tolower(debug_channel),switch,
-                                  "none" = 0,"depth" = 1,"normals" = 2, "uv" = 3, "bvh" = 4,
-                                  "variance" = 5, "normal" = 2, "dpdu" = 6, "dpdv" = 7, "color" = 8, 
-                                  "position" = 10, "direction" = 11, "time" = 12, "shape" = 13,
-                                  "pdf" = 14, "error" = 15, "bounces" = 16, "camera" = 17,
-                                  "ao" = 18, 0))
-    light_direction = c(0,1,0)
-  } else {
-    light_direction = debug_channel
-    debug_channel = 9
-  }
-  if(debug_channel == 4) {
-    message("rayrender must be compiled with option DEBUGBVH for this debug option to work")
   }
   
   if(fov == 0) {

--- a/R/render_scene.R
+++ b/R/render_scene.R
@@ -282,7 +282,8 @@ render_scene = function(scene, width = 400, height = 400, fov = 20,
   if(width < 3 || height < 3) {
     stop("Must specify a minimum width/height of 3 or more pixels")
   }
-  if(preview && interactive && has_gui_capability() && debug_channel == "none") {
+  if(preview && interactive && has_gui_capability() &&
+     !is.numeric(debug_channel) && debug_channel ==  "none") {
     message(
 "--------------------------Interactive Mode Controls---------------------------
 W/A/S/D: Horizontal Movement: | Q/Z: Vertical Movement | Up/Down: Adjust FOV | ESC: Close
@@ -315,7 +316,7 @@ Left Mouse Click: Change Look At (new focal distance) | Right Mouse Click: Chang
   
   camera_info$preview = preview
   camera_info$interactive = interactive
-
+  debug_channel = scene_info$debug_channel  # converted to numeric
   
   #Pathrace Scene
   rgb_mat = render_scene_rcpp(camera_info = camera_info, scene_info = scene_info) 


### PR DESCRIPTION
Hey, was playing around with render_preview and found a small bug.  Fix was simple so I just throw it together here (make sure debug_channel is numeric before testing against it).  Here is the error from the unpatched version (from `?render_preview`:

```
generate_ground(material=diffuse(color="darkgreen")) %>% 
  add_object(sphere(material=diffuse(checkercolor="red"))) %>% 
  render_preview(light_direction = c(-1,-1,0))
## Error in preview && interactive && has_gui_capability() && debug_channel ==  : 
##  'length(x) = 4 > 1' in coercion to 'logical(1)'
```